### PR TITLE
Update client for telegram-bot-api

### DIFF
--- a/schemas.json
+++ b/schemas.json
@@ -2,7 +2,7 @@
   "telegram-bot-api": {
     "schema_version": "9.2.0+20250928014454",
     "source_version": "9.2.0",
-    "source_hash": "4477365s",
+    "source_hash": "2917116827",
     "updated_at": "2025-09-28T01:44:54Z"
   },
   "shikimori-graphql-api": {


### PR DESCRIPTION
This PR updates the client to version 9.2.0 for the API telegram-bot-api.